### PR TITLE
#10 add xml documentation

### DIFF
--- a/Musify/Controllers/AttributeDefinitionsController.cs
+++ b/Musify/Controllers/AttributeDefinitionsController.cs
@@ -54,7 +54,7 @@ namespace Musify.Controllers
         ///     Retrieves an attribute definition by its unique identifier.
         /// </summary>
         /// <remarks>
-        ///     Retrieves the <see cref="AttributeDefinition"/> corresponding to the provided identifier.
+        ///     Retrieves the <see cref="AttributeDefinition"/> corresponding to the provided <paramref name="id"/>>.
         ///     If the attribute definition does not exist, a <see cref="NotFoundResult"/> is returned.
         /// </remarks>
         /// <param name="id">The unique identifier of the attribute definition to retrieve.</param>
@@ -77,7 +77,7 @@ namespace Musify.Controllers
         ///     Retrieves all attribute definitions associated with a specific category.
         /// </summary>
         /// <remarks>
-        ///     Retrieves a list of <see cref="AttributeDefinition"/> entities that belong to the category corresponding to the provided category identifier.
+        ///     Retrieves a list of <see cref="AttributeDefinition"/> entities that belong to the category corresponding to the provided <paramref name="categoryId"/>.
         ///     If the provided category does not exist, a <see cref="NotFoundResult"/> is returned.
         /// </remarks>
         /// <param name="categoryId">The unique identifier of the desired category.</param>
@@ -121,7 +121,8 @@ namespace Musify.Controllers
         /// </summary>
         /// <remarks>
         ///     The provided <see cref="AttributeDefinitionCreateDto"/> is used to create a new <see cref="AttributeDefinition"/> entity in the system.
-        ///     The category identifier must correspond to an existing category; otherwise, a <see cref="BadRequestObjectResult"/> is returned.
+        ///     The category identifier provided in <paramref name="attributeDto"/> must correspond to an existing category;
+        ///     otherwise, a <see cref="BadRequestObjectResult"/> is returned.
         ///     This operation requires admin privileges.
         /// </remarks>
         /// <param name="attributeDto">The DTO used to create and persist the attribute definition.</param>
@@ -158,7 +159,7 @@ namespace Musify.Controllers
         /// </summary>
         /// <remarks>
         ///     The provided <see cref="AttributeDefinitionUpdateDto"/> is used to update an existing <see cref="AttributeDefinition"/> entity in the system.
-        ///     The identifier provided in the URL must match the identifier in the DTO, and a corresponding attribute definition must exist;
+        ///     The <paramref name="id"/> in the URL must match the identifier in the DTO, and a corresponding attribute definition must exist;
         ///     otherwise, a <see cref="BadRequestObjectResult"/> is returned.
         ///     The category identifier must correspond to an existing category; otherwise, a <see cref="BadRequestObjectResult"/> is returned.
         ///     This operation requires admin privileges.
@@ -206,7 +207,7 @@ namespace Musify.Controllers
         /// </summary>
         /// <remarks>
         ///     Deletes an existing <see cref="AttributeDefinition"/> entity corresponding to the provided <paramref name="id"/>.
-        ///     The provided identifier must correspond to an existing attribute definition; otherwise, a <see cref="NotFoundResult"/> is returned.
+        ///     The provided <paramref name="id"/> must correspond to an existing attribute definition; otherwise, a <see cref="NotFoundResult"/> is returned.
         /// </remarks>
         /// <param name="id">The unique identifier of the attribute definition to be deleted.</param>
         /// <returns>

--- a/Musify/Controllers/AttributeDefinitionsController.cs
+++ b/Musify/Controllers/AttributeDefinitionsController.cs
@@ -9,12 +9,12 @@ using Musify.Models;
 namespace Musify.Controllers
 {
     /// <summary>
-    /// Provides endpoints for managing attribute definitions in the system.
+    ///     Provides endpoints for managing attribute definitions in the system.
     /// </summary>
     /// <remarks>
-    /// This controller allows clients to perform CRUD operations on attribute definitions, 
-    /// including retrieving all attribute definitions, retrieving by ID or category, creating new definitions, 
-    /// updating existing ones, and deleting definitions.  Operations outside reading actions require administrative privileges.
+    ///     This controller allows clients to perform CRUD operations on attribute definitions, 
+    ///     including retrieving all attribute definitions, retrieving by ID or category, creating new definitions, 
+    ///     updating existing ones, and deleting definitions.  Operations outside reading actions require administrative privileges.
     /// </remarks>
     [Route("api/[controller]")]
     [ApiController]

--- a/Musify/Controllers/AttributeDefinitionsController.cs
+++ b/Musify/Controllers/AttributeDefinitionsController.cs
@@ -26,7 +26,7 @@ namespace Musify.Controllers
         ///     Initializes a new instance of the <see cref="AttributeDefinitionsController"/> class.
         /// </summary>
         /// <param
-        ///     name="musifyDbContext">The database context used to interact with the Musify database.  This parameter cannot be <see langword="null"/>.
+        ///     name="musifyDbContext">The database context used to interact with the Musify database./>.
         /// </param>
         public AttributeDefinitionsController(MusifyDbContext musifyDbContext)
         {

--- a/Musify/Controllers/AttributeDefinitionsController.cs
+++ b/Musify/Controllers/AttributeDefinitionsController.cs
@@ -8,24 +8,60 @@ using Musify.Models;
 
 namespace Musify.Controllers
 {
+    /// <summary>
+    /// Provides endpoints for managing attribute definitions in the system.
+    /// </summary>
+    /// <remarks>
+    /// This controller allows clients to perform CRUD operations on attribute definitions, 
+    /// including retrieving all attribute definitions, retrieving by ID or category, creating new definitions, 
+    /// updating existing ones, and deleting definitions.  Operations outside reading actions require administrative privileges.
+    /// </remarks>
     [Route("api/[controller]")]
     [ApiController]
     public class AttributeDefinitionsController : ControllerBase
     {
         private MusifyDbContext _musifyDbContext;
 
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="AttributeDefinitionsController"/> class.
+        /// </summary>
+        /// <param
+        ///     name="musifyDbContext">The database context used to interact with the Musify database.  This parameter cannot be <see langword="null"/>.
+        /// </param>
         public AttributeDefinitionsController(MusifyDbContext musifyDbContext)
         {
             _musifyDbContext = musifyDbContext;
         }
 
+        /// <summary>
+        ///     Retrieves the list of all existing <see cref="AttributeDefinition"/> entities.
+        /// </summary>
+        /// <remarks>
+        ///     This operation requires admin or manager privileges.
+        /// </remarks>
+        /// <returns>
+        ///     An <see cref="IActionResult"/> containing the list of all attribute definitions with an HTTP 200 OK status.
+        /// </returns>
         [HttpGet]
+        [Authorize(Roles = $"{UserRole.StoreManager}, {UserRole.WarehouseManager}, {UserRole.Admin}")]
         public async Task<ActionResult> GetAllAttributeDefinitions()
         {
             var attributeDefinitions = await _musifyDbContext.AttributeDefinitions.ToListAsync();
             return Ok(attributeDefinitions);
         }
 
+        /// <summary>
+        ///     Retrieves an attribute definition by its unique identifier.
+        /// </summary>
+        /// <remarks>
+        ///     Retrieves the <see cref="AttributeDefinition"/> corresponding to the provided identifier.
+        ///     If the attribute definition does not exist, a <see cref="NotFoundResult"/> is returned.
+        /// </remarks>
+        /// <param name="id">The unique identifier of the attribute definition to retrieve.</param>
+        /// <returns>
+        ///     An <see cref="IActionResult"/> containing the attribute definition if found; otherwise, a <see
+        ///     cref="NotFoundResult"/> if no attribute definition exists with the specified identifier.
+        /// </returns>
         [HttpGet("{id}")]
         public async Task<IActionResult> GetAttributeDefinitionById(int id)
         {
@@ -37,15 +73,62 @@ namespace Musify.Controllers
             return Ok(attributeDefinition);
         }
 
+        /// <summary>
+        ///     Retrieves all attribute definitions associated with a specific category.
+        /// </summary>
+        /// <remarks>
+        ///     Retrieves a list of <see cref="AttributeDefinition"/> entities that belong to the category corresponding to the provided category identifier.
+        ///     If the provided category does not exist, a <see cref="NotFoundResult"/> is returned.
+        /// </remarks>
+        /// <param name="categoryId">The unique identifier of the desired category.</param>
+        /// <returns>
+        ///     An <see cref="IActionResult"/> containing the list of attribute definitions for the specified category if found;
+        ///     otherwise, a <see cref="NotFoundResult"/> if no category exists with the specified identifier.
+        /// </returns>
         [HttpGet("category/{categoryId}")]
-        public async Task<IActionResult> GetAttributeDefinitionByCategoryId(int categoryId)
+        [Authorize(Roles = $"{UserRole.StoreManager}, {UserRole.WarehouseManager}, {UserRole.Admin}")]
+        public async Task<IActionResult> GetAttributeDefinitionsByCategoryId(int categoryId)
         {
+            var category = await _musifyDbContext.Categories.FindAsync(categoryId);
+            if (category == null)
+            {
+                return NotFound(new { Message = "Category not found." });
+            }
+
             var attributeDefinitions = await _musifyDbContext.AttributeDefinitions
                 .Where(ad => ad.CategoryId == categoryId)
+                .Include(a => a.Category)
                 .ToListAsync();
-            return Ok(attributeDefinitions);
+
+            List<AttributeDefinitionReadDetailedDto> attributeDtos = [];
+            foreach (var attr in attributeDefinitions)
+            {
+                attributeDtos.Add(new AttributeDefinitionReadDetailedDto
+                {
+                    Id = attr.Id,
+                    Name = attr.Name,
+                    DataType = attr.DataType,
+                    CategoryId = attr.CategoryId,
+                    Category = attr.Category
+                });
+            }
+
+            return Ok(attributeDtos);
         }
 
+        /// <summary>
+        ///     Creates an attribute definition based on the provided data.
+        /// </summary>
+        /// <remarks>
+        ///     The provided <see cref="AttributeDefinitionCreateDto"/> is used to create a new <see cref="AttributeDefinition"/> entity in the system.
+        ///     The category identifier must correspond to an existing category; otherwise, a <see cref="BadRequestObjectResult"/> is returned.
+        ///     This operation requires admin privileges.
+        /// </remarks>
+        /// <param name="attributeDto">The DTO used to create and persist the attribute definition.</param>
+        /// <returns>
+        ///     A <see cref="CreatedAtActionResult"/> containing the created attribute definition with an HTTP 201 Created status if successful;
+        ///     otherwise a <see cref="BadRequestObjectResult"/> if the associated category does not exist.
+        /// </returns>
         [HttpPost]
         [Authorize(Roles = UserRole.Admin)]
         public async Task<IActionResult> CreateAttributeDefinition([FromBody] AttributeDefinitionCreateDto attributeDto)
@@ -70,10 +153,31 @@ namespace Musify.Controllers
             return CreatedAtAction(nameof(GetAttributeDefinitionById), new { id = newAttributeDefinition.Id }, newAttributeDefinition);
         }
 
-        [HttpPut]
+        /// <summary>
+        ///     Updates an existing attribute definition with the provided data.
+        /// </summary>
+        /// <remarks>
+        ///     The provided <see cref="AttributeDefinitionUpdateDto"/> is used to update an existing <see cref="AttributeDefinition"/> entity in the system.
+        ///     The identifier provided in the URL must match the identifier in the DTO, and a corresponding attribute definition must exist;
+        ///     otherwise, a <see cref="BadRequestObjectResult"/> is returned.
+        ///     The category identifier must correspond to an existing category; otherwise, a <see cref="BadRequestObjectResult"/> is returned.
+        ///     This operation requires admin privileges.
+        /// </remarks>
+        /// <param name="id">The unique identifier of the attribute definition to be updated.</param>
+        /// <param name="attributeDto">The DTO which holds the updated attributes.</param>
+        /// <returns>
+        ///     A <see cref="NoContentResult"/> if the update is successful;
+        ///     otherwise, a <see cref="BadRequestObjectResult"/> if the IDs do not match or the associated category does not exist,
+        /// </returns>
+        [HttpPut("{id}")]
         [Authorize(Roles = UserRole.Admin)]
-        public async Task<IActionResult> UpdateAttributeDefinition([FromBody] AttributeDefinitionUpdateDto attributeDto)
+        public async Task<IActionResult> UpdateAttributeDefinition(int id, [FromBody] AttributeDefinitionUpdateDto attributeDto)
         {
+            if (id != attributeDto.Id)
+            {
+                return BadRequest("ID in URL does not match ID in body.");
+            }
+
             var existingAttributeDefinition = await _musifyDbContext.AttributeDefinitions.FindAsync(attributeDto.Id);
             if (existingAttributeDefinition == null)
             {
@@ -97,6 +201,18 @@ namespace Musify.Controllers
             return NoContent();
         }
 
+        /// <summary>
+        ///     Deletes an existing attribute definition by its unique identifier.
+        /// </summary>
+        /// <remarks>
+        ///     Deletes an existing <see cref="AttributeDefinition"/> entity corresponding to the provided identifier.
+        ///     The provided identifier must correspond to an existing attribute definition; otherwise, a <see cref="NotFoundResult"/> is returned.
+        /// </remarks>
+        /// <param name="id">The unique identifier of the attribute definition to be deleted.</param>
+        /// <returns>
+        ///     A <see cref="NoContentResult"/> if the deletion is successful;
+        ///     otherwise, a <see cref="NotFoundResult"/> if no attribute definition exists with the specified identifier.
+        /// </returns>
         [HttpDelete("{id}")]
         [Authorize(Roles = UserRole.Admin)]
         public async Task<IActionResult> DeleteAttributeDefinition(int id)

--- a/Musify/Controllers/AttributeDefinitionsController.cs
+++ b/Musify/Controllers/AttributeDefinitionsController.cs
@@ -40,7 +40,7 @@ namespace Musify.Controllers
         ///     This operation requires admin or manager privileges.
         /// </remarks>
         /// <returns>
-        ///     An <see cref="IActionResult"/> containing the list of all attribute definitions with an HTTP 200 OK status.
+        ///     An <see cref="OkObjectResult"/> response containing the list of all attribute definitions.
         /// </returns>
         [HttpGet]
         [Authorize(Roles = $"{UserRole.StoreManager}, {UserRole.WarehouseManager}, {UserRole.Admin}")]
@@ -59,7 +59,7 @@ namespace Musify.Controllers
         /// </remarks>
         /// <param name="id">The unique identifier of the attribute definition to retrieve.</param>
         /// <returns>
-        ///     An <see cref="IActionResult"/> containing the attribute definition if found; otherwise, a <see
+        ///     An <see cref="OkObjectResult"/> containing the attribute definition if found; otherwise, a <see
         ///     cref="NotFoundResult"/> if no attribute definition exists with the specified identifier.
         /// </returns>
         [HttpGet("{id}")]
@@ -126,7 +126,7 @@ namespace Musify.Controllers
         /// </remarks>
         /// <param name="attributeDto">The DTO used to create and persist the attribute definition.</param>
         /// <returns>
-        ///     A <see cref="CreatedAtActionResult"/> containing the created attribute definition with an HTTP 201 Created status if successful;
+        ///     A <see cref="CreatedAtActionResult"/> containing the created attribute definition if successful;
         ///     otherwise a <see cref="BadRequestObjectResult"/> if the associated category does not exist.
         /// </returns>
         [HttpPost]
@@ -205,7 +205,7 @@ namespace Musify.Controllers
         ///     Deletes an existing attribute definition by its unique identifier.
         /// </summary>
         /// <remarks>
-        ///     Deletes an existing <see cref="AttributeDefinition"/> entity corresponding to the provided identifier.
+        ///     Deletes an existing <see cref="AttributeDefinition"/> entity corresponding to the provided <paramref name="id"/>.
         ///     The provided identifier must correspond to an existing attribute definition; otherwise, a <see cref="NotFoundResult"/> is returned.
         /// </remarks>
         /// <param name="id">The unique identifier of the attribute definition to be deleted.</param>

--- a/Musify/Controllers/AuthController.cs
+++ b/Musify/Controllers/AuthController.cs
@@ -9,6 +9,13 @@ using System.Text;
 
 namespace Musify.Controllers
 {
+    /// <summary>
+    ///     Provides endpoints for various authentication-related operations.
+    /// </summary>
+    /// <remarks>
+    ///     This controller allows users to register, log in, confirm their email addresses, and reset their passwords.
+    ///     It utilizes ASP.NET Core Identity for user management and JWT for token generation.
+    /// </remarks>
     [Route("api/[controller]")]
     [ApiController]
     public class AuthController : ControllerBase
@@ -21,6 +28,14 @@ namespace Musify.Controllers
 
         private const int RateLimitMinutes = 2;
 
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="AuthController"/> class.
+        /// </summary>
+        /// <param name="userManager">The user manager instance used to interact with ASP.NET Core Identity users.</param>
+        /// <param name="signInManager">The sign in manager instance used to manage sign ins.</param>
+        /// <param name="tokenService">The token service used to generate JWT tokens for user authentication.</param>
+        /// <param name="emailConfirmTokenService">The token service used to generate email confirmation tokens.</param>
+        /// <param name="emailSender">The email sender service used to send authentication related emails to users.</param>
         public AuthController(
             UserManager<ApplicationUser> userManager,
             SignInManager<ApplicationUser> signInManager,
@@ -35,6 +50,20 @@ namespace Musify.Controllers
             _emailSender = emailSender;
         }
 
+        /// <summary>
+        ///     Handles the user registration process.
+        /// </summary>
+        /// <remarks>
+        ///     Handles the registration of a new user by creating an account with the provided username, email, and password.
+        ///     This method assigns the default "User" role to the newly registered user, generates a JWT token for authentication,
+        ///     and send an email confirmation link to the user's email address.
+        ///     The username must be unique; if it is already taken, a <see cref="BadRequestObjectResult"/> response is returned.
+        /// </remarks>
+        /// <param name="dto">Contains the necessary user data to initialize registration.</param>
+        /// <returns>
+        ///     An <see cref="OkObjectResult"/> if the registration is successful, containing a success message and JWT token;
+        ///     otherwise, a <see cref="BadRequestObjectResult"/> with error details.
+        /// </returns>
         [HttpPost("register")]
         public async Task<ActionResult> Register([FromBody] RegisterDto dto)
         {
@@ -80,6 +109,18 @@ namespace Musify.Controllers
             return BadRequest(ModelState);
         }
 
+        /// <summary>
+        ///     Authenticates a user and generates a JWT token upon successful login.
+        /// </summary>
+        /// <remarks>
+        ///     Authenticates a user based on their credentials. The credentials must be valid, and the user's email must be confirmed;
+        ///     otherwise, an <see cref="UnauthorizedObjectResult"/> response is returned.
+        /// </remarks>
+        /// <param name="dto">Contains the necessary data to authenticate the user.</param>
+        /// <returns>
+        ///     An <see cref="OkObjectResult"/> if the login is successful, containing a success message and JWT token;
+        ///     othewise an <see cref="UnauthorizedObjectResult"/> with error details.
+        /// </returns>
         [HttpPost("login")]
         public async Task<ActionResult> Login([FromBody] LoginDto dto)
         {
@@ -106,6 +147,20 @@ namespace Musify.Controllers
             return Ok(new { Message = "Login successful", token });
         }
 
+        /// <summary>
+        ///     Handles the email confirmation process for a user.
+        /// </summary>
+        /// <remarks>
+        ///     Handles the email confirmation process by validating the provided user ID and confirmation token.
+        ///     The provided user identifier must correspond to an existing user, and the token must be valid;
+        ///     otherwise, appropriate error responses are returned.
+        /// </remarks>
+        /// <param name="userId">The unique identifier of the user.</param>
+        /// <param name="token">The confirmation token sent to the user's email address.</param>
+        /// <returns>
+        ///     An <see cref="OkObjectResult"/> response if the confirmation is successful;
+        ///     otherwise, a <see cref="NotFoundObjectResult"/> if the user is not found, or a <see cref="BadRequestObjectResult"/> if the confirmation fails.
+        /// </returns>
         [HttpGet("confirmemail")]
         public async Task<ActionResult> ConfirmEmail(string userId, string token)
         {
@@ -132,6 +187,18 @@ namespace Musify.Controllers
             return BadRequest(new { Message = "Email confirmation failed", Errors = result.Errors.Select(e => e.Description) });
         }
 
+        /// <summary>
+        ///     Handles resending of the email confirmation link to the user's email address.
+        /// </summary>
+        /// <remarks>
+        ///     Resends the email confirmation link to the specified email address.
+        ///     The email is only resent if the user exists, the email is not already confirmed,
+        ///     and the last email was sent more than a predefined rate limit duration ago to prevent abuse.
+        /// </remarks>
+        /// <param name="dto">Contains the email address to resend the confirmation email to.</param>
+        /// <returns>
+        ///     An <see cref="OkObjectResult"/> response regardless of the outcome to prevent email enumeration.
+        /// </returns>
         [HttpPost("resend-confirmation-email")]
         public async Task<ActionResult> ResendConfirmationEmail([FromBody] ResendConfirmationEmailDto dto)
         {
@@ -144,7 +211,7 @@ namespace Musify.Controllers
 
             if (user.EmailConfirmed)
             {
-                return BadRequest(new { Message = "Email is already confirmed" });
+                return Ok(new { Message = "Email is already confirmed" });
             }
 
             // Rate limiting: Allow resending only if last sent was more than n minutes ago
@@ -176,6 +243,18 @@ namespace Musify.Controllers
             return Ok(new { Message = "Confirmation email resent successfully" });
         }
 
+        /// <summary>
+        ///     Handles forgot password requests by sending a password reset link to the user's email.
+        /// </summary>
+        /// <remarks>
+        ///     The provided user identified by the email address must exist and have a confirmed email, and the last forgot password request
+        ///     must be sent within a rate limit interval to prevent abuse. Even if these conditions are not met,
+        ///     an <see cref="OkObjectResult"/> is returned to prevent email enumeration.
+        /// </remarks>
+        /// <param name="dto">Contains the email address of the user to send the email to.</param>
+        /// <returns>
+        ///     An <see cref="OkObjectResult"/> response regardless of the outcome to prevent email enumeration.
+        /// </returns>
         [HttpPost("forgot-password")]
         public async Task<IActionResult> ForgotPassword([FromBody] ForgotPasswordDto dto)
         {
@@ -215,6 +294,18 @@ namespace Musify.Controllers
             return Ok(new { Message = "If a user was registered with the provided email, a password reset link has been sent." });
         }
 
+        /// <summary>
+        ///     Handles resetting the user's password.
+        /// </summary>
+        /// <remarks>
+        ///     Handles resetting the user's password using a valid reset token. The provided passwords must match.
+        ///     If the user does not exist, an <see cref="OkObjectResult"/> is still returned to prevent user enumeration.
+        /// </remarks>
+        /// <param name="dto">Contains the reset token and the necessary information to reset a user's password.</param>
+        /// <returns>
+        ///     An <see cref="OkObjectResult"/> response if the reset is successful or the user does not exist;
+        ///     otherwise, a <see cref="BadRequestObjectResult"/> with error details.
+        /// </returns>
         [HttpPost("reset-password")]
         public async Task<IActionResult> ResetPassword([FromBody] ResetPasswordDto dto)
         {

--- a/Musify/Controllers/AuthController.cs
+++ b/Musify/Controllers/AuthController.cs
@@ -152,7 +152,7 @@ namespace Musify.Controllers
         /// </summary>
         /// <remarks>
         ///     Handles the email confirmation process by validating the provided user ID and confirmation token.
-        ///     The provided user identifier must correspond to an existing user, and the token must be valid;
+        ///     The provided <paramref name="userId"/> must correspond to an existing user, and the <paramref name="token"/> must be valid;
         ///     otherwise, appropriate error responses are returned.
         /// </remarks>
         /// <param name="userId">The unique identifier of the user.</param>

--- a/Musify/Controllers/CategoriesController.cs
+++ b/Musify/Controllers/CategoriesController.cs
@@ -7,17 +7,33 @@ using Musify.Models;
 
 namespace Musify.Controllers
 {
+    /// <summary>
+    ///     Provides endpoints for managing categories.
+    /// </summary>
+    /// <remarks>
+    ///     This controller allows users to perform CRUD operations on categories.
+    /// </remarks>
     [Route("api/[controller]")]
     [ApiController]
     public class CategoriesController : ControllerBase
     {
         private MusifyDbContext _dbContext;
 
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="CategoriesController"/> class.
+        /// </summary>
+        /// <param name="dbContext">The database context used to interact with the Musify database.</param>
         public CategoriesController(MusifyDbContext dbContext)
         {
             _dbContext = dbContext;
         }
 
+        /// <summary>
+        ///     Retrieves the list of all existing <see cref="Category"/> entities.
+        /// </summary>
+        /// <returns>
+        ///     An <see cref="OkObjectResult"/> response containing the list of categories.
+        /// </returns>
         [HttpGet]
         public async Task<ActionResult<IEnumerable<Category>>> GetAllCategories()
         {
@@ -25,6 +41,18 @@ namespace Musify.Controllers
             return Ok(categories);
         }
 
+        /// <summary>
+        ///     Retrieves a category by its unique identifier.
+        /// </summary>
+        /// <remarks>
+        ///     Retrieves the <see cref="Category"/> corresponding to the provided <paramref name="id"/>.
+        ///     If the category does not exist, a <see cref="NotFoundResult"/> is returned.
+        /// </remarks>
+        /// <param name="id">The unique identifier of the category to retrieve.</param>
+        /// <returns>
+        ///     An <see cref="OkObjectResult"/> containing the category if found;
+        ///     otherwise a <see cref="NotFoundResult"/> if no category exists with the specified identifier.
+        /// </returns>
         [HttpGet("{id}")]
         public async Task<ActionResult<Category>> GetCategoryById(int id)
         {
@@ -36,6 +64,19 @@ namespace Musify.Controllers
             return Ok(category);
         }
 
+        /// <summary>
+        ///     Creates a category based on the provided data.
+        /// </summary>
+        /// <remarks>
+        ///     The provided <see cref="CategoryCreateDto"/> is used to create a new <see cref="Category"/> entity in the system.
+        ///     The parent category given in <paramref name="categoryDto"/> must already exist, else a <see cref="BadRequestObjectResult"/> response is returned.
+        ///     This operation requires admin privileges.
+        /// </remarks>
+        /// <param name="categoryDto">The DTO used to create and persist the category.</param>
+        /// <returns>
+        ///     A <see cref="CreatedAtActionResult"/> containing the created category if successful;
+        ///     otherwise a <see cref="BadRequestObjectResult"/> if the input data is invalid.
+        /// </returns>
         [Authorize(Roles = UserRole.Admin)]
         [HttpPost]
         public async Task<ActionResult<Category>> CreateCategory([FromBody] CategoryCreateDto categoryDto)
@@ -61,6 +102,22 @@ namespace Musify.Controllers
             return CreatedAtAction(nameof(GetCategoryById), new { id = newCategory.Id }, categoryDto);
         }
 
+        /// <summary>
+        ///     Updates an existing category with the provided data.
+        /// </summary>
+        /// <remarks>
+        ///     The provided <see cref="Category"/> is used to update an existing <see cref="Category"/> entity.
+        ///     The <paramref name="id"/> provided in the URL must match the identifier in the <paramref name="category"/> object,
+        ///     and the corresponding category must already exist, else a <see cref="BadRequestObjectResult"/> response is returned.
+        ///     The provided parent category identifier must also exist, else a <see cref="BadRequestObjectResult"/> response is returned.
+        ///     This operation requires admin privileges.
+        /// </remarks>
+        /// <param name="id">The unique identifier of the category to be updated.</param>
+        /// <param name="category">The DTO which holds the updated attributes.</param>
+        /// <returns>
+        ///     An <see cref="OkObjectResult"/> response if the update is successful;
+        ///     otherwise a <see cref="BadRequestObjectResult"/> response if the input data is invalid.
+        /// </returns>
         [Authorize(Roles = UserRole.Admin)]
         [HttpPut("{id}")]
         public async Task<ActionResult<Category>> UpdateCategory(int id, [FromBody] Category category)
@@ -94,6 +151,19 @@ namespace Musify.Controllers
             return Ok(existingCategory);
         }
 
+        /// <summary>
+        ///     Deletes an existing category by its unique identifier.
+        /// </summary>
+        /// <remarks>
+        ///     Deletes an existing <see cref="Category"/> entity corresponding to the provided <paramref name="id"/>.
+        ///     The provided identifier must correspond to an existing category; and the category must not have existing child categories;
+        ///     otherwise, a <see cref="NotFoundResult"/> is returned.
+        /// </remarks>
+        /// <param name="id"></param>
+        /// <returns>
+        ///     A <see cref="NoContentResult"/> if the deletion is successful;
+        ///     otherwise a <see cref="NotFoundResult"/> response.
+        /// </returns>
         [Authorize(Roles = UserRole.Admin)]
         [HttpDelete("{id}")]
         public async Task<ActionResult<Category>> DeleteCategory(int id)

--- a/Musify/Controllers/InstrumentsController.cs
+++ b/Musify/Controllers/InstrumentsController.cs
@@ -9,17 +9,33 @@ using Musify.Models;
 
 namespace Musify.Controllers
 {
+    /// <summary>
+    ///     Provides endpoints for managing instruments.
+    /// </summary>
+    /// <remarks>
+    ///     This controller allows users to perform CRUD operations on instruments.
+    /// </remarks>
     [Route("api/[controller]")]
     [ApiController]
     public class InstrumentsController : ControllerBase
     {
         private MusifyDbContext _dbContext;
 
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="InstrumentsController"/> class.
+        /// </summary>
+        /// <param name="dbContext">The database context used to interact with the Musify database.</param>
         public InstrumentsController(MusifyDbContext dbContext)
         {
             _dbContext = dbContext;
         }
 
+        /// <summary>
+        ///     Retrieves the list of all existing <see cref="Instrument"/> entities.
+        /// </summary>
+        /// <returns>
+        ///     An <see cref="OkObjectResult"/> response containing the list of categories.
+        /// </returns>
         [HttpGet]
         public async Task<ActionResult<IEnumerable<InstrumentReadMinimalDto>>> GetAllInstruments()
         {
@@ -42,6 +58,18 @@ namespace Musify.Controllers
             return Ok(instrumentDtos);
         }
 
+        /// <summary>
+        ///     Retrieves an instrument by its unique identifier.
+        /// </summary>
+        /// <remarks>
+        ///     Retrieves the <see cref="Instrument"/> corresponding to the provided <paramref name="id"/>.
+        ///     If the instrument does not exist, a <see cref="NotFoundResult"/> response is returned.
+        /// </remarks>
+        /// <param name="id">The unique identifier of the instrument to retrieve.</param>
+        /// <returns>
+        ///     An <see cref="OkObjectResult"/> containing the instrument if found;
+        ///     otherwise a <see cref="NotFoundResult"/> if no instrument exists with the specified identifier.
+        /// </returns>
         [HttpGet("{id}")]
         public async Task<ActionResult<InstrumentReadMinimalDto>> GetInstrumentById(int id)
         {
@@ -64,6 +92,19 @@ namespace Musify.Controllers
             return Ok(instrumentDto);
         }
 
+        /// <summary>
+        ///     Creates an instrument based on the provided data.
+        /// </summary>
+        /// <remarks>
+        ///     The provided <see cref="InstrumentCreateDto"/> is used to create a new <see cref="Instrument"/> entity in the system.
+        ///     The associated <see cref="Category"/> must exist; otherwise a <see cref="BadRequestObjectResult"/> response is returned.
+        ///     This operation requires admin privileges.
+        /// </remarks>
+        /// <param name="instrumentDto">The DTO used to create and persist the category.</param>
+        /// <returns>
+        ///     A <see cref="CreatedAtActionResult"/> response containing the created instrument if successful;
+        ///     otherwise a <see cref="BadRequestObjectResult"/> if the input data is invalid.
+        /// </returns>
         [HttpPost]
         [Authorize(Roles = UserRole.Admin)]
         public async Task<ActionResult<InstrumentReadMinimalDto>> CreateInstrument([FromBody] InstrumentCreateDto instrumentDto)
@@ -95,9 +136,24 @@ namespace Musify.Controllers
 
             _dbContext.Instruments.Add(newInstrument);
             await _dbContext.SaveChangesAsync();
-            return CreatedAtAction(nameof(GetInstrumentById), new { id = newInstrument.Id }, instrumentDto);
+            return CreatedAtAction(nameof(GetInstrumentById), new { id = newInstrument.Id }, returnedInstrumentDto);
         }
 
+        /// <summary>
+        ///     Updates an existing instrument with the provided data.
+        /// </summary>
+        /// <remarks>
+        ///     The provided <see cref="InstrumentUpdateDto"/> is used to update an existing <see cref="Instrument"/> entity in the system.
+        ///     The <paramref name="id"/> provided in the URL must match the identifier in the <paramref name="instrumentDto"/> object,
+        ///     The associated category must exist, else a <see cref="BadRequestObjectResult"/> response is returned.
+        ///     This operation requires admin privileges.
+        /// </remarks>
+        /// <param name="id">The unique identifier of the instrument to be updated.</param>
+        /// <param name="instrumentDto">The DTO which holds the updated attributes.</param>
+        /// <returns>
+        ///     An <see cref="OkObjectResult"/> response if the update is successful;
+        ///     otherwise a <see cref="BadRequestObjectResult"/> if the input data is invalid.
+        /// </returns>
         [HttpPut("{id}")]
         [Authorize(Roles = UserRole.Admin)]
         public async Task<ActionResult<Instrument>> UpdateInstrument(int id, [FromBody] InstrumentUpdateDto instrumentDto)
@@ -105,6 +161,12 @@ namespace Musify.Controllers
             if (instrumentDto.Id != id)
             {
                 return BadRequest(new { Message = "Instrument id is invalid." });
+            }
+
+            var category = await _dbContext.Categories.FindAsync(instrumentDto.CategoryId);
+            if (category == null)
+            {
+                return BadRequest(new { Message = "Associated category does not exist." });
             }
 
             var existingInstrument = await _dbContext.Instruments.FindAsync(id);
@@ -123,6 +185,18 @@ namespace Musify.Controllers
             return Ok(existingInstrument);
         }
 
+        /// <summary>
+        ///     Retrieves the list of attribute values associated with a specific instrument.
+        /// </summary>
+        /// <remarks>
+        ///     Retrieves the list of <see cref="InstrumentAttributeValue"/> entities associated with the <see cref="Instrument"/> corrresponding
+        ///     to the provided <paramref name="id"/>. If the instrument does not exist, a <see cref="NotFoundResult"/> response is returned.
+        /// </remarks>
+        /// <param name="id">The unique identifier of the instrument.</param>
+        /// <returns>
+        ///     An <see cref="OkObjectResult"/> containing the list of attribute values if the instrument is found;
+        ///     otherwise a <see cref="NotFoundResult"/> if no instrument exists with the specified identifier.
+        /// </returns>
         [HttpGet("{id}/attributes")]
         public async Task<ActionResult<IEnumerable<InstrumentAttributeValueReadDetailedDto>>> GetAttributesForInstrument(int id)
         {
@@ -158,6 +232,24 @@ namespace Musify.Controllers
             return Ok(attributeDtos);
         }
 
+
+        /// <summary>
+        ///     Adds a new attribute value to a specific instrument.
+        /// </summary>
+        /// <remarks>
+        ///     Add a new <see cref="InstrumentAttributeValue"/> to the <see cref="Instrument"/> corresponding to the provided <paramref name="id"/>.
+        ///     The provided id in the URL must match that in the <paramref name="attribute"/> object and the associated attribute definition must exist;
+        ///     otherwise a <see cref="BadRequestObjectResult"/> response is returned.
+        ///     The <see cref="AttributeDefinition"/> associated with the new attribute value must exist;
+        ///     otherwise a <see cref="BadRequestObjectResult"/> response is returned.
+        ///     This operation requires admin privileges.
+        /// </remarks>
+        /// <param name="id">The unique identifier of the instrument.</param>
+        /// <param name="attribute">The DTO which holds the data used to create the new attribute value.</param>
+        /// <returns>
+        ///     A <see cref="CreatedAtActionResult"/> containing the created attribute value if successful;
+        ///     A <see cref="BadRequestObjectResult"/> if the input data is invalid.
+        /// </returns>
         [HttpPost("{id}/attributes")]
         [Authorize(Roles = UserRole.Admin)]
         public async Task<ActionResult<Instrument>> AddAttributeToInstrument(int id, [FromBody] InstrumentAttributeValueCreateDto attribute)
@@ -207,6 +299,25 @@ namespace Musify.Controllers
                 });
         }
 
+        /// <summary>
+        ///     Updates an attribute value of a specific instrument.
+        /// </summary>
+        /// <remarks>
+        ///     Updates a <see cref="InstrumentAttributeValue"/> identified by the provided <paramref name="attributeId"/> associated with
+        ///     the <see cref="Instrument"/> corresponding to the provided <paramref name="instrumentId"/>.
+        ///     The provided identifiers in the URL must match those in the <paramref name="attribute"/> object, and the associated instrument and
+        ///     attribute definition must exist; otherwise a <see cref="BadRequestObjectResult"/> response is returned.
+        ///     The newly associated <see cref="AttributeDefinition"/> referenced in <paramref name="attribute"/> must also exist;
+        ///     otherwise a <see cref="BadRequestObjectResult"/> response is returned.
+        ///     This operation requires admin privileges.
+        /// </remarks>
+        /// <param name="instrumentId">The unique identifier of the instrument.</param>
+        /// <param name="attributeId">The unique identifier of the attribute value.</param>
+        /// <param name="attribute">The DTO which holds the data used to update the specific attribute value.</param>
+        /// <returns>
+        ///     An <see cref="OkObjectResult"/> response if the update was successful;
+        ///     otherwise a <see cref="BadRequestObjectResult"/> if the input data is invalid.
+        /// </returns>
         [HttpPut("{instrumentId}/attributes/{attributeId}")]
         [Authorize(Roles = UserRole.Admin)]
         public async Task<ActionResult<InstrumentAttributeValue>> UpdateAttributeOfInstrument(
@@ -277,6 +388,19 @@ namespace Musify.Controllers
             return Ok(attributeValueReadDto);
         }
 
+        /// <summary>
+        ///     Deletes an existing instrument by its unique identifier.
+        /// </summary>
+        /// <remarks>
+        ///     Deletes an existing <see cref="Instrument"/> corresponding to the provided <paramref name="id"/>.
+        ///     The provided identifier must correspond to an existing instrument; otherwise a <see cref="NotFoundResult"/> response is returned.
+        ///     This operation requires admin privileges.
+        /// </remarks>
+        /// <param name="id">The unique identifier of the instrument to be deleted.</param>
+        /// <returns>
+        ///     A <see cref="NoContentResult"/> if the deletion is successful;
+        ///     otherwise a <see cref="NotFoundResult"/> response if no instrument exists with the specified identifier.
+        /// </returns>
         [HttpDelete("{id}")]
         [Authorize(Roles = UserRole.Admin)]
         public async Task<IActionResult> DeleteInstrument(int id)
@@ -292,6 +416,21 @@ namespace Musify.Controllers
             return NoContent();
         }
 
+        /// <summary>
+        ///     Deletes a specific attribute value from an instrument.
+        /// </summary>
+        /// <remarks>
+        ///     Deletes an <see cref="InstrumentAttributeValue"/> corresponding to the provided <paramref name="attributeId"/> associated with the instrument
+        ///     identified by the provided <paramref name="instrumentId"/>.
+        ///     Both identifiers must correspond to existing entities; and the targeted <see cref="InstrumentAttributeValue"/> must be associated with the
+        ///     targeted <see cref="Instrument"/>; otherwise a <see cref="NotFoundResult"/> response is returned.
+        ///     This operation requires admin privileges.
+        /// </remarks>
+        /// <param name="instrumentId">The unique identifier of the instrument.</param>
+        /// <param name="attributeId">The unique identifier of the attribute value.</param>
+        /// <returns>
+        ///     A <see cref="NoContentResult"/> if the deletion is successful; otherwise a <see cref="NotFoundResult"/> response if input data is invalid.
+        /// </returns>
         [HttpDelete("{instrumentId}/attributes/{attributeId}")]
         [Authorize(Roles = UserRole.Admin)]
         public async Task<IActionResult> DeleteAttributeOfInstrument(int instrumentId, int attributeId)


### PR DESCRIPTION
Closes #10 

Provide XML documentation tags for all action methods of controllers. An exception is the ShopItemController, which has a lacking implementation for now. Documentation will be added once proper testing of the implementation has taken place.